### PR TITLE
Explicitly destroy the buffer pointers

### DIFF
--- a/decoder.js
+++ b/decoder.js
@@ -12,7 +12,11 @@ const decoder = (dict, delta) => {
     const resultSize = _decoder.__Z15get_result_sizev();
     const resultView = new Uint8Array(_decoder.HEAP8.buffer, resultPointer, resultSize);
     const result = new Uint8Array(resultView);
+
+    _decoder.__Z14destroy_bufferPh(dict_ptr)
+    _decoder.__Z14destroy_bufferPh(delta_ptr)
     _decoder.__Z4freev();
+
     return result;
 }
 

--- a/encoder.js
+++ b/encoder.js
@@ -12,7 +12,11 @@ const encoder = (dict, target) => {
     const resultSize = _encoder.__Z15get_result_sizev();
     const resultView = new Uint8Array(_encoder.HEAP8.buffer, resultPointer, resultSize);
     const result = new Uint8Array(resultView);
+
+    _encoder.__Z14destroy_bufferPh(dict_ptr)
+    _encoder.__Z14destroy_bufferPh(target_ptr)
     _encoder.__Z4freev();
+
     return result;
 }
 


### PR DESCRIPTION
This fixes a memory leak.

The internal buffers were never destroyed which lead to incremental memory usage.